### PR TITLE
Fixing a bug where npm can't find npm 1.0.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dependencies" : {
         "hashish" : ">=0.0.2",
         "sprintf" : ">=0.1.1",
-        "npm" : "1.0.90",
+        "npm" : "1.0.106",
         "optimist": ">=0.1.0"
     },
     "keywords" : [


### PR DESCRIPTION
npm ERR! error installing npmtop@0.1.1 Error: version not found: 1.0.90 : npm/1.0.90
npm ERR! error installing npmtop@0.1.1     at Request._callback (/Users/veselintodorov/.nvm/v0.6.0/lib/node_modules/npm/lib/utils/npm-registry-client/request.js:180:12)
npm ERR! error installing npmtop@0.1.1     at Request.callback (/Users/veselintodorov/.nvm/v0.6.0/lib/node_modules/npm/node_modules/request/main.js:99:22)
npm ERR! error installing npmtop@0.1.1     at Request.<anonymous> (/Users/veselintodorov/.nvm/v0.6.0/lib/node_modules/npm/node_modules/request/main.js:361:18)
npm ERR! error installing npmtop@0.1.1     at Request.emit (events.js:67:17)
npm ERR! error installing npmtop@0.1.1     at IncomingMessage.<anonymous> (/Users/veselintodorov/.nvm/v0.6.0/lib/node_modules/npm/node_modules/request/main.js:327:16)
npm ERR! error installing npmtop@0.1.1     at IncomingMessage.emit (events.js:88:20)
npm ERR! error installing npmtop@0.1.1     at HTTPParser.onMessageComplete (http.js:137:23)
npm ERR! error installing npmtop@0.1.1     at CleartextStream.ondata (http.js:1125:24)
npm ERR! error installing npmtop@0.1.1     at CleartextStream._push (tls.js:363:27)
npm ERR! error installing npmtop@0.1.1     at SecurePair.cycle (tls.js:679:20)
npm info unbuild /private/tmp/npmtop/node_modules/npmtop
npm info preuninstall npmtop@0.1.1
npm info uninstall npmtop@0.1.1